### PR TITLE
handle cookie popup

### DIFF
--- a/linkage_checker/linkage_check.py
+++ b/linkage_checker/linkage_check.py
@@ -44,8 +44,22 @@ def run_linkage_checker_with_selenium(
     browser.get(LINKAGE_CHECKER_URL)
     logger.debug("webpage " + browser.current_url + " loaded")
 
+    if browser_screenshots:
+        browser.save_screenshot(BROWSER_SCREENSHOT_PATH)
+
+    # accept coockies (if requested)
+    #
+    element = browser.find_element_by_css_selector("a.wt-link.cck-actions-button.ea_ignore")
+    if element:
+        element.click()
+        browser.find_element_by_css_selector("div.cck-actions a.wt-link").click()
+
+    if browser_screenshots:
+        browser.save_screenshot(BROWSER_SCREENSHOT_PATH)
+
     # simulating webpage interaction
     # click on the "Check new metadata" button
+    #
     browser.find_element_by_id("newMetadataBtn").click()
     # this second .click() ensures that the button is properly clicked (a single click is apparently not enough)
     browser.find_element_by_id("newMetadataBtn").click()


### PR DESCRIPTION
# Omschrijving

Het uitvoeren van de linkage checker via selenium werd geblokkeerd door een popup voor het wel of niet accepteren van cookies. Het testscript is verder uitgebreid met een paar stappen waarin de cookies (minimaal) geaccepteerd worden

https://dev.kadaster.nl/jira/browse/PDOK-14330

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Bugfix


# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [x] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [x] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [x] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)